### PR TITLE
[1.2.1] Improve app layout accross devices

### DIFF
--- a/src/addons/version_info.js
+++ b/src/addons/version_info.js
@@ -23,6 +23,10 @@ const version_info = [
         name: '1.2.0',
         release: '23/11/22',
     },
+    {
+        name: '1.2.1',
+        release: '25/11/22',
+    },
 ];
 
 export default version_info;

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -157,8 +157,8 @@ input[type="checkbox"]:checked+input {
 }
 
 .start-play {
-    height: 2.5rem;
-    width: 6rem;
+    padding: .6rem;
+    width: 40vw;
     font-size: 1.2rem;
     font-weight: 550;
     border-radius: 20%;
@@ -203,7 +203,7 @@ input[type="checkbox"]:checked+input {
 }
 
 /* Landscape orientation - any size mobiles from small to large viewports */ 
-@media screen and (orientation: landscape) and (max-width: 1100px) { 
+@media screen and (orientation: landscape) and (max-width: 1000px) { 
     /* Transform portrait (default) flow into horizontal grid */
 
     .app-section-box[data-type="difficulty"] {
@@ -221,9 +221,8 @@ input[type="checkbox"]:checked+input {
     .app-section-main {
         display: grid;
         grid-template-rows: 1;
-        grid-template-columns: repeat(3, 25% 50% 25%);
+        grid-template-columns: repeat(3, 30% 40% 30%);
         grid-template-areas: "theme-section   difficulty-section   options-section";
-        padding: .3rem;
     }
 
     /* and... some styling ! */
@@ -241,13 +240,18 @@ input[type="checkbox"]:checked+input {
         font-size: .8rem;
     }
 
+    .items-text {
+        padding: .45rem 0;
+        display: inline;
+    }
+
     .difficulty {
         padding: 1.5rem;
     }
 
     .box-difficulty {
-        grid-template-columns: repeat(2, 10vw);
-        grid-template-rows: repeat(2, 10vw);
+        grid-template-columns: repeat(2, 16vw);
+        grid-template-rows: repeat(2, 11vw);
     }
 
     .box-items {
@@ -263,15 +267,15 @@ input[type="checkbox"]:checked+input {
 
     .content-box[data-type="content-options"] {
         display: grid;
-        grid-template-columns: 1;
-        grid-template-rows: auto;
+        grid-template-columns: 1fr; /* Add extra 1fr there once option box grows - it'll make option box two-column */
+        grid-template-rows: 12vw 12vw;
         align-items: center;
         justify-items: center;
     }
 
     .items-icons {
-        width: 5vw;
-        height: 5vw;
+        width: 6.2vw;
+        height: 6.2vw;
     }
 
     .items-vis {
@@ -298,8 +302,9 @@ input[type="checkbox"]:checked+input {
     }
 
     .start-play {
-        width: 12vw;
-        height: 5vw;
+        width: 20vw;
+        padding: .3rem;
+        margin: .2rem;
     }
 }
 
@@ -307,7 +312,7 @@ input[type="checkbox"]:checked+input {
 
 
 /* Huge sized screens with landscape (non-mobiles) - ideal for desktops*/
-@media screen and (orientation: landscape) and (min-width: 1101px) { 
+@media screen and (orientation: landscape) and (min-width: 1001px) { 
 
     /* Transform portrait (default) flow into horizontal grid */
 
@@ -326,7 +331,7 @@ input[type="checkbox"]:checked+input {
     .app-section-main {
         display: grid;
         grid-template-rows: 1;
-        grid-template-columns: repeat(3, 25% 50% 25%);
+        grid-template-columns: repeat(3, 30% 40% 30%);
         grid-template-areas: "theme-section   difficulty-section   options-section";
         padding: .8rem;
     }
@@ -335,7 +340,7 @@ input[type="checkbox"]:checked+input {
 
     .content-title-text {
         font-size: 2rem;
-        padding-top: 1rem;
+        padding-top: .5rem;
     }
 
     .app-text {
@@ -347,8 +352,8 @@ input[type="checkbox"]:checked+input {
     }
 
     .box-difficulty {
-        grid-template-columns: repeat(2, 10vw);
-        grid-template-rows: repeat(2, 10vw);
+        grid-template-columns: repeat(2, 15vw);
+        grid-template-rows: repeat(2, 9vw);
     }
 
     .box-items {
@@ -394,8 +399,41 @@ input[type="checkbox"]:checked+input {
         font-size: 3rem;
     }
 
-    .start-play {
-        width: 10vw;
-        height: 4vw;
+    .start {
+        padding: 0;
     }
+
+    .start-play {
+        width: 20vw;
+        padding: .75rem;
+        margin: .1rem 0 .6rem 0;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 540px) and (min-width: 540px) {
+    /* Portrait-oriented tablets */
+
+    .box-difficulty {
+        grid-template-columns: repeat(2, 15vw);
+        grid-template-rows: repeat(2, 15vw);
+    }
+
+    .items-icons {
+        width: 8.5vw;
+        height: 8.5vw;
+    }
+
+    .app-text, .items-text  {
+        font-size: 1.3rem;
+        font-weight: 550;
+    }
+
+    .items-vis {
+        scale: 120%;
+    }
+
+    .difficulty {
+        font-size:  1rem;
+    }
+    
 }

--- a/src/styles/sudoku.css
+++ b/src/styles/sudoku.css
@@ -1,5 +1,12 @@
 @import url('https://fonts.googleapis.com/css?family=Audiowide|Sofia');
 
+
+/* Default styles goes for portrait-oriented mobile devices */
+
+body {
+    overflow-x: hidden !important; 
+}
+
 .all {
     width: 100%;
     height: 100%;
@@ -49,8 +56,8 @@
 .sudoku-board {
     box-sizing: border-box;
     display: grid;
-    grid-template-columns: repeat(3, 7rem); /* grid-template-columns: repeat(3, 7rem) grid-template-columns: repeat(3, 33vw); */
-    grid-template-rows: repeat(3, 7rem); /* grid-template-rows: repeat(3, 7rem) grid-template-rows: repeat(3, 33vw); */
+    grid-template-columns: repeat(3, 33vw); /* grid-template-columns: repeat(3, 7rem) grid-template-columns: repeat(3, 33vw); */
+    grid-template-rows: repeat(3, 33vw); /* grid-template-rows: repeat(3, 7rem) grid-template-rows: repeat(3, 33vw); */
     /* border: .2rem solid #000; */
 }
 
@@ -70,8 +77,8 @@
 .numbers-box {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(2, 1fr);
-    width: 80%;
+/*     grid-template-rows: repeat(3, 1fr); */
+    width: 90%;
     border-radius: 10%;
 }
 
@@ -116,15 +123,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: .2rem;
     font-weight: 600;
     border: .2rem dotted hsla(124, 5%, 5%, .6);
     font-weight: 700;
     border-radius: 10%;
-}
-
-.option-0 {
-    padding: 1.3rem;
+    padding: .5rem;
 }
 
 .option:hover {
@@ -207,12 +210,11 @@
 }
 
 .new-sudoku {
-    width: 6rem;
-    margin: 1rem;
-    padding: .4rem;
-    height: 2.5rem;
+    width: 40vw;
+    margin: 1.6rem 0 1.1rem 0;
+    padding: .6rem;
     color: #000;
-    border-radius: 25%;
+    border-radius: 15%;
 }
 
 .new-sudoku:hover {
@@ -315,6 +317,7 @@
 }
 
 @media screen and (orientation: landscape) and (max-width: 1000px) {
+    /* Landscape oriented screen for mobiles */
 
     .game-elems {
         display: grid;
@@ -335,29 +338,31 @@
     }
 
     .sudoku-board {
-        grid-template-rows: repeat(3, 6rem);
-        grid-template-columns: repeat(3, 6rem);
+        grid-template-rows:    repeat(3, 15.2vw);                /* repeat(3, 6rem);  */
+        grid-template-columns: repeat(3, 15.2vw);               /* repeat(3, 6rem); */
     }
 
     .numbers-box {
         display: grid;
-        grid-template-columns: repeat(3, 7.3vw);
-        grid-template-rows: repeat(3, 7.3vw);
-        grid-template-areas: 
-            "digit   digit   digit"
-            "digit   digit   digit"
-            "digit   digit   digit"
-            "rubber  rubber  rubber"
-        ;
+        grid-template-columns:none;
+        grid-template-rows: repeat(3, 1fr);
+        width: 80%;
     }
 
     .option {
-        padding: .8rem;
+        height: 4.8vw;
     }
 
     .option-0 { /*aka. the rubber*/
         grid-area: rubber;
     }
+
+    .new-sudoku {
+        width: 30vw;
+        margin: .4rem 0 1.1rem 0;
+        padding: .55rem;
+    }
+    
 }
 
 
@@ -403,14 +408,15 @@
     }
 
     .sudoku-board {
-        grid-template-rows: repeat(3, 8rem);
-        grid-template-columns: repeat(3, 8rem);
+        grid-template-rows: repeat(3, 11vw); /* 8 rem */
+        grid-template-columns: repeat(3, 11vw); /* 8 rem */
+        max-width: 45vw;
     }
 
     .numbers-box {
         display: grid;
-        grid-template-columns: repeat(3, 7.3vw);
-        grid-template-rows: repeat(3, 7.3vw);
+        grid-template-columns: repeat(3, 8vw); /* 7.3vw */
+        grid-template-rows: repeat(3, 8vw); /* 7.3vw */
         grid-template-areas: 
             "digit   digit   digit"
             "digit   digit   digit"
@@ -420,11 +426,43 @@
     }
 
     .option {
-        font-size: 1.8rem;
+        font-size: 2rem;
         padding: .8rem;
     }
 
     .option-0 { /*aka. the rubber*/
         grid-area: rubber;
+        padding: 1.3rem;
+    }
+
+    .new-sudoku {
+        width: 25vw;
+        margin: .4rem 0 1.1rem 0;
+        padding: .55rem;
+        font-size: 1.15rem;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 620px) and (min-width: 620px) {
+    /* Portrait-oriented tablets */
+    html{
+        font-size: 1.3rem;
+    }
+    .sudoku-board {
+        font-size: 1.6rem;
+        grid-template-columns: repeat(3, 30vw); /* grid-template-columns: repeat(3, 7rem) grid-template-columns: repeat(3, 33vw); */
+        grid-template-rows: repeat(3, 30vw); /* grid-template-rows: repeat(3, 7rem) grid-template-rows: repeat(3, 33vw); */
+    }
+
+    .option {
+        font-size: 1.4rem;
+        padding: .5rem;
+    }
+    
+    .new-sudoku {
+        width: 40vw;
+        margin: 1.6rem 0 1.1rem 0;
+        padding: .7rem;
+        font-size: 1.4rem;
     }
 }

--- a/src/styles/toolbox.css
+++ b/src/styles/toolbox.css
@@ -9,9 +9,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 4rem;
-    margin: .4rem;
-    width: 4rem;
+    margin: .3rem;
+   /*  height: 4rem; */ min-height: 20vw;
+   /*  width: 4rem; */ min-width: 20vw;
     border: .3rem double #fff;
     border-radius:  30%;
 }
@@ -108,7 +108,7 @@
 }
 
 
-@media screen and (orientation: landscape) and (max-width: 1100px) {
+@media screen and (orientation: landscape) and (max-width: 1000px) {
     .tool-box-all {
         display: flex;
         align-items: center;
@@ -118,19 +118,23 @@
     .tool-box {
         margin: 0 auto;
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        grid-template-rows: repeat(2, 1fr);
+        gap: .15rem;
+        grid-template-columns: repeat(1, 1fr);
+        grid-template-rows: repeat(4, 1fr);
         grid-template-areas: 
-            "option-info       option-pencilmark"
-            "option-btn-back   option-btn-forth";
+            "option-info"       
+            "option-pencilmark"
+            "option-btn-back"   
+            "option-btn-forth";
         align-items: center;
         justify-content: center;
         justify-items: center;
     }
     
     .tool {
-        width: 10vw;
-        height: 10vw;
+        width: 14.4vw;
+        height: 7.2vw;
+        min-height: 0; min-width: 0; /* set temporarily, get rid of during dev*/
     }
 
     .tool[data-name="info"] {
@@ -154,7 +158,7 @@
 
 
 
-@media screen and (orientation: landscape) and (min-width: 1101px) {
+@media screen and (orientation: landscape) and (min-width: 1001px) {
 
     .tool-box-all {
         display: flex;
@@ -176,12 +180,13 @@
     }
     
     .tool-icon {
-        font-size: 1.8rem;
+        font-size: 2.1rem;
     }
 
     .tool {
-        width: 10vw;
-        height: 10vw;
+        width: 11vw;
+        height: 11vw;
+        min-height: 0; min-width: 0; /* set temporarily, get rid of during dev*/
     }
 
     .tool[data-name="info"] {
@@ -198,5 +203,14 @@
 
     .tool[data-name="pencil"] {
         grid-area: option-pencilmark;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 540px) and (min-width: 540px) {
+    /* Portrait-oriented tablets */
+    .tool {
+        width: 20vw;
+        height: 12vw;
+        min-height: 0; min-width: 0; /* set temporarily, get rid of during dev*/
     }
 }


### PR DESCRIPTION
This commit provides another layout update. The main changes regards the layout for tablets (which is finally out) and for landscape-oriented devices. Furthermore, app for huge screens and portrait-oriented devices received a bit of changes in this regard, but less impactful.

Sudoku view:
- Adjusted Toolbox elements sizing, to better fit for screens, which has relatively similiar viewport width and height (f.e.: tablets);
- Maximized Sudoku board size and increased board digits size for better solving experience;
- Signifficantly changed a Toolbox and NumbersBox layout for landscape-oriented devices (to make them fit that type of screen well);
- Modified a "New Sudoku" button to make it more spacious and placed the text inside single line;

Landing Page view:
- Changed play button size to make it longer;
- Changed difficulty box sizing and slightly modified size for theme box buttons (accross all device types);
- Extra size modify and layout modifications for all elements (for tablets and landscape-oriented devices);