### PR TITLE
[1.2.2] Correct dialog boxes sizing

### DIFF
--- a/public/logo_new.svg
+++ b/public/logo_new.svg
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="288"
+   height="204"
+   viewBox="0 0 76.199998 53.975002"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="logo_new..svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     units="px"
+     inkscape:zoom="2.6205012"
+     inkscape:cx="123.25886"
+     inkscape:cy="82.808586"
+     inkscape:window-width="1335"
+     inkscape:window-height="728"
+     inkscape:window-x="6"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8427" />
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient911">
+      <stop
+         style="stop-color:#00fff3;stop-opacity:1"
+         offset="0"
+         id="stop906" />
+      <stop
+         style="stop-color:#002fff;stop-opacity:0"
+         offset="1"
+         id="stop908" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3479">
+      <stop
+         style="stop-color:#00fff3;stop-opacity:1;"
+         offset="0"
+         id="stop3475" />
+      <stop
+         style="stop-color:#00fff3;stop-opacity:0;"
+         offset="1"
+         id="stop3477" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3991"
+       id="linearGradient8431"
+       gradientUnits="userSpaceOnUse"
+       x1="27.889175"
+       y1="54.396278"
+       x2="27.516838"
+       y2="26.05155"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3991">
+      <stop
+         style="stop-color:#103836;stop-opacity:1"
+         offset="0"
+         id="stop3987" />
+      <stop
+         style="stop-color:#18797e;stop-opacity:0.71764708"
+         offset="1"
+         id="stop3989" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient5211"
+       gradientUnits="userSpaceOnUse"
+       x1="27.84831"
+       y1="59.822086"
+       x2="29.23587"
+       y2="6.3591304"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient5999"
+       gradientUnits="userSpaceOnUse"
+       x1="27.030945"
+       y1="38.339161"
+       x2="27.516838"
+       y2="26.05155"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient5933"
+       gradientUnits="userSpaceOnUse"
+       x1="29.991152"
+       y1="59.695431"
+       x2="29.664223"
+       y2="6.3623567"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient908"
+       gradientUnits="userSpaceOnUse"
+       x1="7.3286538"
+       y1="42.716347"
+       x2="26.760891"
+       y2="23.685947"
+       spreadMethod="reflect"
+       gradientTransform="translate(-0.36972471,0.32640917)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3991"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       x1="27.889175"
+       y1="54.396278"
+       x2="27.516838"
+       y2="26.05155"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3479"
+       id="linearGradient3481"
+       x1="7.5679097"
+       y1="-50.323891"
+       x2="10.623813"
+       y2="2.352412"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3479"
+       id="linearGradient4497"
+       gradientUnits="userSpaceOnUse"
+       x1="7.5679097"
+       y1="-50.323891"
+       x2="10.623813"
+       y2="2.352412"
+       gradientTransform="translate(39.430594,45.319596)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient4499"
+       gradientUnits="userSpaceOnUse"
+       x1="27.030945"
+       y1="38.339161"
+       x2="27.516838"
+       y2="26.05155"
+       spreadMethod="reflect"
+       gradientTransform="translate(39.430594,45.319596)" />
+  </defs>
+  <g
+     inkscape:label="Warstwa 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g8427"
+       style="mix-blend-mode:normal;stroke:url(#linearGradient8431)"
+       transform="translate(8.4413571,-5.8482009)">
+      <rect
+         style="mix-blend-mode:normal;fill:#00fff3;fill-opacity:0;stroke:url(#linearGradient5211);stroke-width:0.79375;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.937838;paint-order:stroke markers fill"
+         id="rect846"
+         width="10.13798"
+         height="40.69471"
+         x="7.1724672"
+         y="13.229685"
+         ry="3.2315636"
+         transform="rotate(-0.43151796)" />
+      <rect
+         style="mix-blend-mode:normal;fill:#00fff3;fill-opacity:0;stroke:url(#linearGradient908);stroke-width:0.575204;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.937838;paint-order:stroke markers fill"
+         id="rect3687"
+         width="8.6387014"
+         height="8.0675478"
+         x="-10.660095"
+         y="41.902752"
+         ry="1.0040858"
+         transform="rotate(-45.71327)" />
+      <g
+         id="g2672-3"
+         transform="matrix(-1,0,0,1,58.652382,0.20193338)"
+         style="stroke:url(#linearGradient910)">
+        <rect
+           style="opacity:1;fill:#00fff3;fill-opacity:0;stroke:url(#linearGradient5933);stroke-width:0.79375;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.937838;paint-order:stroke markers fill"
+           id="rect846-68"
+           width="10.13798"
+           height="40.69471"
+           x="9.0292025"
+           y="13.172273"
+           ry="3.2315636"
+           transform="rotate(-0.43151803)" />
+        <rect
+           style="fill:url(#linearGradient3481);fill-opacity:0;stroke:url(#linearGradient5999);stroke-width:0.575248;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.937838;paint-order:stroke markers fill;opacity:1"
+           id="rect846-6-3"
+           width="10.356483"
+           height="20.922827"
+           x="-0.80849981"
+           y="-40.459499"
+           ry="1.6614799"
+           transform="rotate(130.84521)" />
+        <rect
+           style="mix-blend-mode:normal;fill:url(#linearGradient4497);fill-opacity:0;stroke:url(#linearGradient4499);stroke-width:0.575248;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.937838;paint-order:stroke markers fill"
+           id="rect846-6-3-6"
+           width="10.356483"
+           height="20.922827"
+           x="38.622097"
+           y="4.8600965"
+           ry="1.6614799"
+           transform="matrix(0.65401772,0.75647923,0.75647923,-0.65401772,0,0)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/addons/version_info.js
+++ b/src/addons/version_info.js
@@ -27,6 +27,10 @@ const version_info = [
         name: '1.2.1',
         release: '25/11/22',
     },
+    {
+        name: '1.2.2',
+        release: '26/11/22',
+    },
 ];
 
 export default version_info;

--- a/src/components/Info.js
+++ b/src/components/Info.js
@@ -22,7 +22,6 @@ function Info(props) {
         dispatch(stopTimer(true));
         document.body.scrollTop = 0; // Safari
         document.documentElement.scrollTop = 0; // Chrome, Firefox, IE and Opera
-        document.body.style.overflow = 'hidden';
     }, [])
 
     return (
@@ -69,7 +68,7 @@ function Info(props) {
                         <div className="info-box-author-text"> Created by: </div>
                         <div className="info-box-author-logo">
                             <a className="author-logo-box" href="https://github.com/Martimex" target='_blank' rel="noreferrer">
-                                <img className="author-logo" alt="author_logo" src="author.svg" ></img>
+                                <img className="author-logo" alt="author_logo" src="logo_new.svg" ></img>
                             </a> 
                         </div>
                     </div>
@@ -77,7 +76,7 @@ function Info(props) {
                 </div>
 
                 <div className={`info-box info-${props.theme} info-box-new-sizing`} datatype="outro">
-                    <div className="info-close" onClick={() => {document.documentElement.requestFullscreen(); document.body.style.overflow = 'auto'; dispatch(addExtraView({extraViewName: ''})); dispatch(stopTimer(false)); /* props.setCheckInfo(false); */}}> Close </div>
+                    <div className="info-close" onClick={() => {document.documentElement.requestFullscreen(); dispatch(addExtraView({extraViewName: ''})); dispatch(stopTimer(false)); /* props.setCheckInfo(false); */}}> Close </div>
                 </div>
             </div>
         </div>

--- a/src/components/Reset.js
+++ b/src/components/Reset.js
@@ -20,7 +20,6 @@ function Reset(props) {
     useEffect(() => {
         document.body.scrollTop = 0; // Safari
         document.documentElement.scrollTop = 0; // Chrome, Firefox, IE and Opera
-        document.body.style.overflow = 'hidden';
     })
 
     return (

--- a/src/components/Sudoku.js
+++ b/src/components/Sudoku.js
@@ -364,6 +364,7 @@ function Sudoku() {
         if(isSudokuSolved) {
             dispatch(stopTimer(true));
             dispatch(sudokuSolved(true));
+            dispatch(addExtraView({extraViewName: 'win'}));
         }
 
         function checkIfSolved(current_board, win_board) {
@@ -433,6 +434,9 @@ function Sudoku() {
             function fireAsync() {
                 difficulty = engine.hideDigits(queried_difficulty, theme);
                 clearTimeout(timeOut);
+
+                // Last but not least - force a full screen mode
+                document.documentElement.requestFullscreen();
             }
 
             function checkAsyncCompletion() {
@@ -483,6 +487,17 @@ function Sudoku() {
                 }
             }
         }
+
+        else if(extra_view) {
+            // If there is a top-level extra window layer
+            document.body.style.overflowY = 'hidden';
+        }
+
+        else if(!extra_view) {
+            // When user closes extra window
+            document.body.style.overflowY = 'auto';
+        }
+
     }, [extra_view])
 
     // Perform engine operations

--- a/src/components/Win.js
+++ b/src/components/Win.js
@@ -17,7 +17,6 @@ function Win(props) {
     useEffect(() => {
         document.body.scrollTop = 0; // Safari
         document.documentElement.scrollTop = 0; // Chrome, Firefox, IE and Opera
-        document.body.style.overflow = 'hidden';
     })
 
     return(
@@ -28,7 +27,7 @@ function Win(props) {
                 </div>
 
                 <div className={`screen-description screen-description-${props.final_difficulty}`} >
-                    Congratulations! You've just solved Sudoku {props.final_difficulty} !
+                    Congratulations! You've just solved Sudoku {props.final_difficulty}!
                     {isTimeEnabled === true && (
                         <div className="time-summary"> 
                             <div className="time-text"> Solving time:  </div>

--- a/src/styles/info.css
+++ b/src/styles/info.css
@@ -1,3 +1,8 @@
+.author-logo {
+    scale: 2.1;
+    padding: 0 1.1rem;
+}
+
 .info-box-new-sizing {
     max-width: none;
     width: 100%;
@@ -32,6 +37,10 @@
     align-content: center;
     justify-content: center;
     justify-items: center;
+}
+
+.info-box {
+    min-width: 80vw;
 }
 
 .info-box-grid-content {
@@ -168,7 +177,11 @@
 
 /**/
 
-@media screen and (orientation: landscape) and (max-width: 1100px) {
+@media screen and (orientation: landscape) and (max-width: 1000px) {
+
+    .info-box {
+        min-width: 40vw;
+    }
 
     .info-box-grid-content {
         padding: .4rem;
@@ -200,9 +213,10 @@
 
 }
 
-@media screen and (orientation: landscape) and (min-width: 1101px) {
+@media screen and (orientation: landscape) and (min-width: 1001px) {
     .info-box {
         padding: .75rem;
+        min-width: 35vw;
     }
     
     .info-box-grid-content {
@@ -237,5 +251,12 @@
 
     .info-close {
         font-size: 1.6rem;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 540px) and (min-width: 540px) {
+    .info-box {
+        padding: .75rem;
+        min-width: 70vw;
     }
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -2,7 +2,7 @@
     position: absolute;
     left: 0%;
     top: 0%;
-    width: 100%; height: 100vh;
+    width: 100%; height: 100%;
     background: #222d;
     overflow: hidden;
     display: flex;
@@ -86,7 +86,7 @@
     color: hsl(120, 60%, 45%);
 }
 
-@media screen and (orientation: landscape) and (max-width: 1100px) {
+@media screen and (orientation: landscape) and (max-width: 1000px) {
 
     .reset-box, .win-screen, .info-box {
         max-width: 50%;
@@ -105,7 +105,7 @@
     }
 }
 
-@media screen and (orientation: landscape) and (min-width: 1101px) {
+@media screen and (orientation: landscape) and (min-width: 1001px) {
     .reset-box, .win-screen, .info-box {
         max-width: 40%;
     }
@@ -120,5 +120,11 @@
 
     .choose-box {
         padding: 1.3rem;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 540px) and (min-width: 540px) {
+    .reset-box, .win-screen, .info-box {
+        max-width: 65%;
     }
 }

--- a/src/styles/win.css
+++ b/src/styles/win.css
@@ -125,12 +125,21 @@
     font-size: 1.3rem;
 }
 
-@media screen and (orientation: landscape) and (max-width: 1100px) {
+@media screen and (orientation: landscape) and (max-width: 1000px) {
     /* Win screen for mobiles looks gr8 ! -> no media query needed */
+    .win-screen {
+        max-width: 50%;
+    }
 }
 
-@media screen and (orientation: landscape) and (min-width: 1101px) {
+@media screen and (orientation: landscape) and (min-width: 1001px) {
     .win-screen {
-        max-width: 30%;
+        max-width: 35%;
+    }
+}
+
+@media screen and (orientation: portrait) and (min-height: 540px) and (min-width: 540px) {
+    .win-screen {
+        max-width: 70%;
     }
 }


### PR DESCRIPTION
Another and probably last changes regarding size adjustments for now. This time a Win, Reset and Info screen received some modifications:

1. Win Screen:
- Received proper sizing for Win box. Also Win Screen includes its' fixed sizing version for tablets. Very minor text modification.

2. Reset screen:
- Received new  individual sizing, targeted for tablets.

3. Info screen:
- Received fixed sizing for huge screens and also landscape-oriented mobile devices. Added fixed version for tablets aswell. Furthermore, changed logo to a brand new one (in the "created by" section).

And some minor improvements/fixes:

1. Once Sudoku game is loaded, a full screen mode is requested (could be disabled). The main purpose is to enchance solving experience, especially for mobile devices.

2. Fixed an issue, where dialog boxes allowed to use horizontal scrollbar. Using it is now temporarily disabled, until such dialog box is closed.